### PR TITLE
Update constants using 2018 CODATA values

### DIFF
--- a/mosc.c
+++ b/mosc.c
@@ -23,7 +23,7 @@ static NuType matterFlavor = nue_type;
 static double putMix[3][3][2];
 
 /* 2*sqrt(2)*Gfermi in (eV^2-cm^3)/(mole-GeV) - for e<->[mu,tau] */
-static const double tworttwoGf = 1.52588e-4;
+static const double tworttwoGf = 1.5264932449499477998e-4;
 
 /***********************************************************************
   moscerr
@@ -200,7 +200,7 @@ void propagate_vac(double Ain[][3][2], double L, double E,
 		   double Mix[][3][2], double dmVacVac[][3],
 		   double Aout[][3][2]) {
   int a, b, i, j, k;
-  double LoverE = 2.534*L/E;
+  double LoverE = 2.5338653580781978866*L/E;
   double X[3][3][2], A[3][3][2], q;
   
   /* Make the X matrix (eq. 11 simplified since we're in vaccuum) */
@@ -486,7 +486,7 @@ void getA(double L, double E, double rho,
   double X[3][3][2];
   static double product[3][3][3][2];
   /* (1/2)*(1/(h_bar*c)) in units of GeV/(eV^2-km) */
-  const double LoEfac = 2.534;
+  const double LoEfac = 2.5338653580781978866;
 
   if ( phase_offset==0.0 ) {
     get_product(L, E, rho, Mix, dmMatVac, dmMatMat, antitype, product);


### PR DESCRIPTION
While this may not affect any practical results, it makes precise comparisons to other calculations easier. 

Constants were recaclulated at high precision with [Arb](https://arblib.org) using the following code:

    #include <arb.h>

    int main(){
        slong prec=1024; //use 1024 bit precision
        
        arb_t pi;
        arb_init(pi);
        arb_const_pi(pi, prec);
        
        arb_t h;
        arb_init(h);
        arb_set_str(h,"6.62607015e-34",prec); //J*s, exact value
        
        arb_t c;
        arb_init(c);
        arb_set_ui(c,299792458); //m/s, exact value
        
        arb_t eV;
        arb_init(eV);
        arb_set_str(eV,"1.602176634e-19",prec); //J/eV, exact value
        
        arb_t LoEfac;
        arb_init(LoEfac);
        
        arb_t tmp, tmp2;
        arb_init(tmp);
        arb_init(tmp2);
        
        arb_mul(tmp,h,c,prec); // h*c [J m]
        arb_div(tmp2,tmp,pi,prec); // (h*c)/pi [J m]
        arb_div(LoEfac,eV,tmp2,prec); // pi/(h*c) [(J/eV)/(J m) == 1/(eV m)]
        printf("LoEfac: "); arb_printd(LoEfac, 20); printf(" 1/(eV m)\n");
        
        arb_div_ui(tmp, LoEfac, 1000000000, prec); // pi/(h*c) [GeV/(eV^2 m)]
        arb_mul_ui(tmp2, tmp, 1000, prec); // pi/(h*c) [GeV/(eV^2 km)]
        printf("LoEfac: "); arb_printd(tmp2, 20); printf(" GeV/(eV^2 km)\n");
        
        arb_t N_A;
        arb_init(N_A);
        arb_set_str(N_A,"6.02214076e23",prec); //1/mol, exact value
        
        arb_t G_F0;
        arb_init(G_F0);
        arb_set_str(G_F0,"[1.1663787000e-5 +/- 0.000000510e-5]",prec); // eV^-2, approx
        
        printf("G_F0: "); arb_printd(G_F0, 20); printf(" ev^2\n");
        
        arb_set_ui(tmp,2);
        arb_sqrt(tmp2,tmp,prec);
        
        arb_set_ui(tmp,2); //2
        arb_sqrt(tmp2,tmp,prec); //sqrt(2)
        arb_mul_ui(tmp, tmp2, 2, prec); //2*sqrt(2)
        arb_mul(tmp2, tmp, G_F0, prec); //2*sqrt(2)*G_F0 [1/eV^2]
        
        arb_t tworttwoGf;
        arb_init(tworttwoGf);
        arb_mul(tworttwoGf, tmp2, N_A, prec); //2*sqrt(2)*G_F0*N_A [1/(eV^2 mol)]
        
        printf("tworttwoGf: "); arb_printd(tworttwoGf, 20); printf(" 1/(eV^2 mol)\n");
        
        arb_set_ui(tmp,2); //2
        arb_mul(tmp2, tmp, LoEfac, prec); //(2*pi)/(h*c) [1/(eV m)]
        arb_inv(tmp, tmp2, prec); //(h*c)/(2*pi) [eV m]
        printf("eVm: "); arb_printd(tmp, 20); printf(" 1/(eV m)\n");
        arb_mul_ui(tmp2, tmp, 100, prec); //(h*c)/(2*pi) [eV cm]
        arb_pow_ui(tmp, tmp2, 3, prec); //((h*c)/(2*pi))^3 [(eV cm)^3]
        
        arb_div_ui(tmp2, tworttwoGf, 1000000000, prec); //2*sqrt(2)*G_F0*N_A [1/(GeV eV mol)]
        arb_mul(tworttwoGf, tmp2, tmp, prec); //2*sqrt(2)*G_F0*N_A [(eV^2 cm^3)/(GeV mol)]
        printf("tworttwoGf: "); arb_printd(tworttwoGf, 20); printf(" (eV^2 cm^3)/(mol GeV)\n");
    }
