### PR TITLE
Fixes some problems in the installed CMake Config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,12 @@ endif()
 
 SET(HEADERS EarthDensity.h 
 	BargerPropagator.h 
+  NeutrinoPropagator.h
 	mosc.h
 	mosc3.h)
 
 SET(SOURCE EarthDensity.cc 
-	BargerPropagator.cc 
+	BargerPropagator.cc
 	mosc.c
 	mosc3.c)
 

--- a/Prob3plusplusConfig.cmake.in
+++ b/Prob3plusplusConfig.cmake.in
@@ -7,8 +7,8 @@ get_filename_component(Prob3plusplus_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH
 
 include(${Prob3plusplus_CMAKE_DIR}/Prob3plusplusTargets.cmake)
 
-if(NOT TARGET Prob3plusplus::Prob3++)
-  message(FATAL_ERROR "After including ${Prob3plusplus_CMAKE_DIR}/Prob3plusplusTargets.cmake, expected target: Prob3plusplus::Prob3++ was not declared.")
+if(NOT TARGET Prob3plusplus::Prob3plusplus)
+  message(FATAL_ERROR "After including ${Prob3plusplus_CMAKE_DIR}/Prob3plusplusTargets.cmake, expected target: Prob3plusplus::Prob3plusplus was not declared.")
 endif()
 
 find_path(Prob3plusplus_INCLUDE_DIR
@@ -31,6 +31,6 @@ if(NOT TARGET Prob3plusplus::All)
   add_library(Prob3plusplus::All INTERFACE IMPORTED)
   set_target_properties(Prob3plusplus::All PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES "${Prob3plusplus_INCLUDE_DIR}"
-      INTERFACE_LINK_LIBRARIES Prob3plusplus::Prob3++
+      INTERFACE_LINK_LIBRARIES Prob3plusplus::Prob3plusplus
   )
 endif()

--- a/Prob3plusplusConfig.cmake.in
+++ b/Prob3plusplusConfig.cmake.in
@@ -7,32 +7,22 @@ get_filename_component(Prob3plusplus_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH
 
 include(${Prob3plusplus_CMAKE_DIR}/Prob3plusplusTargets.cmake)
 
+if(NOT TARGET Prob3plusplus::Prob3++)
+  message(FATAL_ERROR "After including ${Prob3plusplus_CMAKE_DIR}/Prob3plusplusTargets.cmake, expected target: Prob3plusplus::Prob3++ was not declared.")
+endif()
+
 find_path(Prob3plusplus_INCLUDE_DIR
 NAMES mosc.h
 PATHS ${Prob3plusplus_CMAKE_DIR}/../include
 )
 
-find_path(Prob3plusplus_BIN_DIR
-NAMES Prob3plusplus-config
-PATHS ${Prob3plusplus_CMAKE_DIR}/../bin
-)
-
-find_path(Prob3plusplus_PREFIX
-NAMES setup.sh
-PATHS ${Prob3plusplus_CMAKE_DIR}/../
-)
-
 message(STATUS "Prob3plusplus_INCLUDE_DIR: ${Prob3plusplus_INCLUDE_DIR}")
-message(STATUS "Prob3plusplus_BIN_DIR: ${Prob3plusplus_BIN_DIR}")
-message(STATUS "Prob3plusplus_PREFIX: ${Prob3plusplus_PREFIX}")
 message(STATUS "Prob3plusplus_VERSION: ${Prob3plusplus_VERSION}")
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Prob3plusplus
   REQUIRED_VARS 
-    Prob3plusplus_INCLUDE_DIR 
-    Prob3plusplus_BIN_DIR
-    Prob3plusplus_PREFIX
+    Prob3plusplus_INCLUDE_DIR
   VERSION_VAR
     Prob3plusplus_VERSION
 )


### PR DESCRIPTION
Not sure how I didn't notice these obvious errors before, but CMake should now be able to include Prob3plusplus fine either being built via CPM or being `find_package`d from a binary install.