### PR TITLE
Tweak Cmake

### DIFF
--- a/Prob3plusplusConfig.cmake.in
+++ b/Prob3plusplusConfig.cmake.in
@@ -13,9 +13,12 @@ endif()
 
 find_path(Prob3plusplus_INCLUDE_DIR
 NAMES mosc.h
-PATHS ${Prob3plusplus_CMAKE_DIR}/../include
+PATHS
+  ${Prob3plusplus_CMAKE_DIR}/../include
+  ${Prob3plusplus_CMAKE_DIR}/../../../include
 )
 
+message(STATUS "Prob3plusplus_CMAKE_DIR: ${Prob3plusplus_CMAKE_DIR}")
 message(STATUS "Prob3plusplus_INCLUDE_DIR: ${Prob3plusplus_INCLUDE_DIR}")
 message(STATUS "Prob3plusplus_VERSION: ${Prob3plusplus_VERSION}")
 


### PR DESCRIPTION
Whe re making T2K RW I was having following error
```
CMake Error in app/CMakeLists.txt:
  Imported target "Prob3plusplus::All" includes non-existent path
    "Prob3plusplus_INCLUDE_DIR-NOTFOUND"
  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:
  * The path was deleted, renamed, or moved to another location.
  * An install or uninstall procedure did not complete successfully.
  * The installation package was faulty and references files it does not
  provide.
```
Here a paths, you can see why it is not finding actual paths.
```
Prob3plusplus_CMAKE_DIR: /mnt/home/kskwarczynski/T2K_OA/T2KReWeight/develop/build/Linux/lib/cmake/Prob3plusplus
Actual Include Path  /mnt/home/kskwarczynski/T2K_OA/T2KReWeight/develop/build/Linux/include/mosc.h
```

Therafore I modified cmake config to avoid this issue.